### PR TITLE
add subtract operator to Kenkenizer

### DIFF
--- a/lib/kenken.rb
+++ b/lib/kenken.rb
@@ -10,6 +10,15 @@ module Kenkenizer
 
     var.first.to_s * count
   end
+
+  def -(other = '')
+    b = binding.of_caller(1)
+    var = b.eval('local_variables').each do |v|
+      break v if self.hash == v.hash
+    end
+
+    var.first.to_s.delete(other)
+  end
 end
 
 class Kenken

--- a/lib/kenken.rb
+++ b/lib/kenken.rb
@@ -5,6 +5,10 @@ module Kenkenizer
     to_s * count    
   end
 
+  def -(other = '')
+    to_s.delete(other)
+  end
+
   def to_s
     @str
   end

--- a/test/kenken_test.rb
+++ b/test/kenken_test.rb
@@ -26,6 +26,16 @@ class KenkenTest < Minitest::Test
     ken = Kenken.new("hayapi")
     assert_equal ken.to_s, "hayapi"
   end
+
+  def test_subtract
+    kenken = Kenken.new("ken")
+    assert_equal (kenken - "e"), "knkn"
+  end
+
+  def test_subtract_when_str_is_hayapi
+    kenken = Kenken.new("hayapi")
+    assert_equal (kenken - "e"), "knkn"
+  end
 end
 
 class StringTest < Minitest::Test
@@ -49,18 +59,23 @@ class StringTest < Minitest::Test
     assert_equal (ken ^ 2), "kenken"
   end
 
-  def test_kenkenizer_subtract
-    obj = Kenken.new("kenken")
-    assert_equal (obj - 'e'), "knkn"
-  end
-  
-  def test_string_subtract
-    obj = String.new("kenken")
-    assert_equal (obj - 'e'), "knkn"
+  def test_string_subtact
+    kenken = String.new("ken")
+    assert_equal (kenken - "e"), "knkn"
   end
 
-  def test_string_literal_subtract
-    obj = "kenken"
-    assert_equal (obj - 'e'), "knkn"
+  def test_string_subtact_when_str_is_hayapi
+    kenken = String.new("hayapi")
+    assert_equal (kenken - "e"), "knkn"
+  end
+
+  def test_string_literal_subtact
+    kenken = "ken"
+    assert_equal (kenken - "e"), "knkn"
+  end
+
+  def test_string_literal_subtact_when_str_is_hayapi
+    kenken = "hayapi"
+    assert_equal (kenken - "e"), "knkn"
   end
 end

--- a/test/kenken_test.rb
+++ b/test/kenken_test.rb
@@ -19,4 +19,19 @@ class KenkenTest < Minitest::Test
     obj = "ken"
     assert_equal (obj ^ 2), "kenken"
   end
+
+  def test_kenkenizer_subtract
+    obj = Kenken.new("kenken")
+    assert_equal (obj - 'e'), "knkn"
+  end
+  
+  def test_string_subtract
+    obj = String.new("kenken")
+    assert_equal (obj - 'e'), "knkn"
+  end
+
+  def test_string_literal_subtract
+    obj = "kenken"
+    assert_equal (obj - 'e'), "knkn"
+  end
 end


### PR DESCRIPTION
Add a subtract operator (`-`) to Kenkenizer to make it more computable.

```rb
ken = Kenken.new("kenken")
puts ken - 'e' #=> "knkn"
```
