### PR TITLE
Fix string class extended case

### DIFF
--- a/lib/kenken.rb
+++ b/lib/kenken.rb
@@ -16,7 +16,7 @@ module Kenkenizer
     b = binding.of_caller(2)
     b.eval('local_variables').find do |v|
       var = b.eval(v.to_s)
-      self == var
+      self.equal?(var)
     end
   end
 end

--- a/test/kenken_test.rb
+++ b/test/kenken_test.rb
@@ -44,12 +44,24 @@ class StringTest < Minitest::Test
     assert_equal (ken ^ 2), "kenken"
   end
 
+  def test_string_pow_when_same_str_is_defined
+    tanaken = String.new("ken")
+    ken = String.new("ken")
+    assert_equal (ken ^ 2), "kenken"
+  end
+
   def test_string_pow_when_str_is_hayapi
     ken = String.new("hayapi")
     assert_equal (ken ^ 2), "kenken"
   end
 
   def test_string_literal_pow
+    ken = "ken"
+    assert_equal (ken ^ 2), "kenken"
+  end
+
+  def test_string_literal_pow_when_same_str_is_defined
+    tanaken = "ken"
     ken = "ken"
     assert_equal (ken ^ 2), "kenken"
   end


### PR DESCRIPTION
When the same string is defined with some local variables, it doesn't work as expected.

```ruby
tanaken = String.new("ken")
ken = String.new("ken")
puts ken ^ 2 #=> "tanakentanaken"
```

After this change, it work as expected.

```ruby
tanaken = String.new("ken")
ken = String.new("ken")
puts ken ^ 2 #=> "kenken"
```